### PR TITLE
remove: Unneeded lodash dependency causes problems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "handlebars-helper-br",
+  "version": "0.1.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "handlebars-helper-br",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
     }
   ],
   "main": "./index.js",
-  "dependencies": {
-    "lodash": "~2.4.0"
-  },
   "keywords": [
     "assemble",
     "assemblehelper",


### PR DESCRIPTION
I see no reason to have lodash as dependency.
It only causes problems with security in the "future".